### PR TITLE
Turret and shooter mechanisms controllable

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -34,10 +34,12 @@ import frc.robot.commands.DrivetrainPowerTestCommand;
 import frc.robot.commands.DriveControls;
 import frc.robot.commands.ExampleCommand;
 import frc.robot.commands.MagazineControls;
+import frc.robot.commands.ShooterControls;
 import frc.robot.commands.SquareTestCommand;
 import frc.robot.commands.TeleopCommand;
 import frc.robot.commands.TestCommand;
 import frc.robot.commands.TurnCommand;
+import frc.robot.commands.TurretControls;
 
 /**
  * This class is where the bulk of the robot should be declared. Since
@@ -67,15 +69,17 @@ public class RobotContainer {
   private final ExampleCommand autoCommand = new ExampleCommand(drivetrain, bling);
   private final DriveControls teleDrive = new DriveControls(drivetrain);
   private final MagazineControls teleMagazine = new MagazineControls(magazine);
+  private final ShooterControls teleShooter = new ShooterControls(shooter);
   private final CollectorControls teleCollect = new CollectorControls(collector);
   private final CollectCommand collect = new CollectCommand(collector, magazine, bling, 0.5, 5000);
+  private final TurretControls teleTurret = new TurretControls(turret);
   private final DriveForwardCommand forward = new DriveForwardCommand(drivetrain, bling, 0.25, 0.35);
   private final TurnCommand turn90 = new TurnCommand(drivetrain, bling, -Math.PI / 2, 2.00);
   private final TurnCommand turn = new TurnCommand(drivetrain, bling, 0.9 * Math.PI, 1.20);
   private final SquareTestCommand squareTest = new SquareTestCommand(drivetrain, bling, 3, 1, 0.5, 1.75);
   private final ChaseAndCollectCellsCommand chaseAndCollect = new ChaseAndCollectCellsCommand(drivetrain, collector,
       magazine, cellTracker, bling, 5, true, 0, 1.5, 1.0);
-  private final ParallelCommandGroup teleopCommand = teleDrive.alongWith(teleCollect).alongWith(teleMagazine);
+  private final ParallelCommandGroup teleopCommand = teleDrive.alongWith(teleCollect).alongWith(teleShooter);
 
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -130,7 +134,6 @@ public class RobotContainer {
 
   public Command getTestCommand() {
     return teleDrive;
-
   }
 
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -81,12 +81,13 @@ public class RobotContainer {
   private final SquareTestCommand squareTest = new SquareTestCommand(drivetrain, bling, 3, 1.5, 0.5, 2.25);
   private final ChaseAndCollectCellsCommand chaseAndCollect = new ChaseAndCollectCellsCommand(drivetrain, collector,
       magazine, cellTracker, bling, 5, true, 0, 1.5, 1.0);
-  private final ParallelCommandGroup teleopCommand3 = teleDrive.alongWith(teleCollect).alongWith(teleShooter);
   private final ChaseCommand chase = new ChaseCommand(drivetrain, cellTracker, bling, 2.5, 2.0, true);
   private final CollectCommand collect = new CollectCommand(drivetrain, collector, magazine, bling);
   private final MagazineCommand runMag = new MagazineCommand(magazine, bling);
   private final DriveToPointCommand toPoint = new DriveToPointCommand(drivetrain, bling, 1.0, 1.0, 0.75);
-  private final ParallelCommandGroup teleopCommand = teleDrive.alongWith(teleCollect);
+
+  private final ParallelCommandGroup teleopCommand = teleDrive.alongWith(teleMagazine).alongWith(teleShooter);
+
   private final SequentialCommandGroup chaseCollectAndRunMag = chase.andThen(collect, runMag);
 
   /**
@@ -111,7 +112,7 @@ public class RobotContainer {
    * passing it to a {@link edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
   private void configureButtonBindings() {
-    JoystickButton magazineUpBinding = new JoystickButton(OI.operatorController, XboxController.Button.kY.value);
+    JoystickButton magazineUpBinding = new JoystickButton(OI.operatorController, XboxController.Button.kA.value);
     magazineUpBinding.whenPressed(new AdvanceMagazineCommand(magazine));
   }
 
@@ -128,7 +129,7 @@ public class RobotContainer {
   // Command that we run in teleoperation mode.
   public Command getTeleopCommand() {
     drivetrain.resetRobotOdometry();
-    return teleopCommand3;
+    return teleopCommand;
   }
 
   public Command getTestCommand() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -75,7 +75,7 @@ public class RobotContainer {
   private final SquareTestCommand squareTest = new SquareTestCommand(drivetrain, bling, 3, 1, 0.5, 1.75);
   private final ChaseAndCollectCellsCommand chaseAndCollect = new ChaseAndCollectCellsCommand(drivetrain, collector,
       magazine, cellTracker, bling, 5, true, 0, 1.5, 1.0);
-  private final ParallelCommandGroup teleopCommand = teleDrive.alongWith(teleCollect);
+  private final ParallelCommandGroup teleopCommand = teleDrive.alongWith(teleCollect).alongWith(teleMagazine);
 
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.

--- a/src/main/java/frc/robot/commands/CollectorControls.java
+++ b/src/main/java/frc/robot/commands/CollectorControls.java
@@ -37,16 +37,16 @@ public class CollectorControls extends CommandBase {
     @Override
     public void execute() {
         if (OI.operatorController.getAButton()) {
-            power = -0.5;
+            power = 0.75;
         } else {
             power = 0;
         }
         SmartDashboard.putNumber("Collector Power", power);
         collector.setCollect(power);
-        if (OI.operatorController.getXButtonPressed()) {
+        if (OI.operatorController.getBumperPressed(Hand.kLeft)) {
             collector.lower();
         }
-        if (OI.operatorController.getYButtonPressed()) {
+        if (OI.operatorController.getBumperPressed(Hand.kRight)) {
             collector.raise();
         }
     }

--- a/src/main/java/frc/robot/commands/CollectorControls.java
+++ b/src/main/java/frc/robot/commands/CollectorControls.java
@@ -36,13 +36,19 @@ public class CollectorControls extends CommandBase {
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-        if (OI.operatorController.getBumper(Hand.kLeft)) {
+        if (OI.operatorController.getAButton()) {
             power = -0.5;
         } else {
             power = 0;
         }
         SmartDashboard.putNumber("Collector Power", power);
         collector.setCollect(power);
+        if (OI.operatorController.getXButtonPressed()) {
+            collector.lower();
+        }
+        if (OI.operatorController.getYButtonPressed()) {
+            collector.raise();
+        }
     }
 
     // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/MagazineControls.java
+++ b/src/main/java/frc/robot/commands/MagazineControls.java
@@ -4,6 +4,7 @@
 
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.Magazine;
@@ -31,6 +32,9 @@ public class MagazineControls extends CommandBase {
   @Override
   public void execute() {
     magazineVelocity = OI.operatorController.getRawAxis(2);
+    // if (OI.operatorController.getBumper(Hand.kLeft)) {
+    //   magazineVelocity *= 2;
+    // }
     //SmartDashboard.putNumber("Magazine Power", magazineVelocity);
     magazine.setVelocity(magazineVelocity);
     // magazine.setVelocity(magazineVelocity);

--- a/src/main/java/frc/robot/commands/ShootCommand.java
+++ b/src/main/java/frc/robot/commands/ShootCommand.java
@@ -14,8 +14,8 @@ public class ShootCommand extends CommandBase {
     @SuppressWarnings({ "PMD.UnusedPrivateField", "PMD.SingularField" })
     private final Shooter shooter;
     private final Bling bling;
-    private final double hoodAngle;
-    private final double maxVelocity;
+    private final double hoodPosition;
+    private final double maxPower;
     private final long milliseconds;
     private boolean getInit;
     private long initialTime;
@@ -32,11 +32,11 @@ public class ShootCommand extends CommandBase {
      *                     to.
      * @param milliseconds The milliseconds this command will run for.
      */
-    public ShootCommand(Shooter shooter, Bling bling, double hoodAngle, double maxVelocity, long milliseconds) {
+    public ShootCommand(Shooter shooter, Bling bling, double hoodPosition, double maxPower, long milliseconds) {
         this.shooter = shooter;
         this.bling = bling;
-        this.hoodAngle = MathUtil.clamp(hoodAngle, shooter.getMinHoodAngle(), shooter.getMaxHoodAngle());
-        this.maxVelocity = maxVelocity;
+        this.hoodPosition = hoodPosition;
+        this.maxPower = maxPower;
         this.milliseconds = milliseconds;
         addRequirements(shooter);
         addRequirements(bling);
@@ -50,7 +50,7 @@ public class ShootCommand extends CommandBase {
      * @param bling   The bling used by this command.
      */
     public ShootCommand(Shooter shooter, Bling bling) {
-        this(shooter, bling, shooter.getHoodAngle(), 2.0, 3000);
+        this(shooter, bling, shooter.getHoodPosition(), 0.5, 3000);
     }
 
     // Called when the command is initially scheduled.
@@ -63,22 +63,22 @@ public class ShootCommand extends CommandBase {
     @Override
     public void execute() {
         // TODO: Bling
-        if (getInit && Math.abs(shooter.getHoodAngle() - hoodAngle) < 0.02) {
+        if (getInit && Math.abs(shooter.getHoodPosition() - hoodPosition) < 0.02) {
             initialTime = System.currentTimeMillis();
             getInit = false;
         } else if (getInit) {
-            shooter.setHoodAngle(hoodAngle);
+            shooter.setHoodPosition(hoodPosition);
         }
         time = System.currentTimeMillis();
         if (time - initialTime < milliseconds) {
-            shooter.setFlywheelVelocity(maxVelocity);
+            shooter.setFlywheelPower(maxPower);
         }
     }
 
     // Called once the command ends or is interrupted.
     @Override
     public void end(boolean interrupted) {
-        shooter.setFlywheelVelocity(0.0);
+        shooter.setFlywheelPower(0.0);
     }
 
     // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/ShooterControls.java
+++ b/src/main/java/frc/robot/commands/ShooterControls.java
@@ -27,7 +27,6 @@ public class ShooterControls extends CommandBase {
   public void initialize() {
     shooter.setFlywheelPower(0);
     shooter.setHoodPower(0);
-    shooter.setFlywheelPower(0);
   }
 
   // Called every time the scheduler runs while the command is scheduled.
@@ -45,11 +44,10 @@ public class ShooterControls extends CommandBase {
     //   OI.operatorController.setRumble(RumbleType.kLeftRumble, 0);
     //   OI.operatorController.setRumble(RumbleType.kRightRumble, 0.5);
     // }
-    flywheelPower = 0.01 * OI.operatorController.getRawAxis(3);
-    hoodPower = OI.operatorController.getRawAxis(1) * 0.5;
-    shooter.setFlywheelPower(flywheelPower);
-    shooter.setHoodPower(hoodPower);
-    shooter.setFlywheelPower(flywheelPower);
+    //flywheelPower = 0.01 * OI.operatorController.getRawAxis(3);
+    hoodPower = MathUtil.clamp(OI.operatorController.getRawAxis(1) * 0.1, -0.05, 0.05);
+//    shooter.setFlywheelPower(flywheelPower);
+    shooter.setHoodPosition(16.306*0.5+16.306*0.4*OI.operatorController.getRawAxis(1));
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/ShooterControls.java
+++ b/src/main/java/frc/robot/commands/ShooterControls.java
@@ -1,0 +1,64 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpiutil.math.MathUtil;
+import frc.robot.subsystems.OI;
+import frc.robot.subsystems.Shooter;
+
+public class ShooterControls extends CommandBase {
+  Shooter shooter;
+  double flywheelPower;
+  double hoodPower;
+
+  public ShooterControls(Shooter shooter) {
+    this.shooter = shooter;
+    flywheelPower = 0;
+    hoodPower = 0;
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    shooter.setFlywheelPower(0);
+    shooter.setHoodPower(0);
+    shooter.setFlywheelPower(0);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    // OI.operatorController.setRumble(RumbleType.kLeftRumble, 0);
+    // OI.operatorController.setRumble(RumbleType.kRightRumble, 0);
+    // if (OI.operatorController.getRawButtonPressed(XboxController.Button.kBumperLeft.value)) {
+    //   flywheelPower += MathUtil.clamp(flywheelPower + 0.25, 0, 0.75);
+    //   OI.operatorController.setRumble(RumbleType.kLeftRumble, 0.5);
+    //   OI.operatorController.setRumble(RumbleType.kRightRumble, 0);
+    // }
+    // if (OI.operatorController.getRawButtonPressed(XboxController.Button.kBumperLeft.value)) {
+    //   flywheelPower += MathUtil.clamp(flywheelPower + 0.25, 0, 0.5);
+    //   OI.operatorController.setRumble(RumbleType.kLeftRumble, 0);
+    //   OI.operatorController.setRumble(RumbleType.kRightRumble, 0.5);
+    // }
+    flywheelPower = 0.01 * OI.operatorController.getRawAxis(3);
+    hoodPower = OI.operatorController.getRawAxis(1) * 0.5;
+    shooter.setFlywheelPower(flywheelPower);
+    shooter.setHoodPower(hoodPower);
+    shooter.setFlywheelPower(flywheelPower);
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/ShooterControls.java
+++ b/src/main/java/frc/robot/commands/ShooterControls.java
@@ -46,8 +46,8 @@ public class ShooterControls extends CommandBase {
     // }
     //flywheelPower = 0.01 * OI.operatorController.getRawAxis(3);
     hoodPower = MathUtil.clamp(OI.operatorController.getRawAxis(1) * 0.1, -0.05, 0.05);
-//    shooter.setFlywheelPower(flywheelPower);
-    shooter.setHoodPosition(16.306*0.5+16.306*0.4*OI.operatorController.getRawAxis(1));
+    //    shooter.setFlywheelPower(flywheelPower);
+    shooter.setHoodPosition(shooter.minHoodPosition + 2.0 * Math.PI);
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/ShooterControls.java
+++ b/src/main/java/frc/robot/commands/ShooterControls.java
@@ -26,8 +26,15 @@ public class ShooterControls extends CommandBase {
   @Override
   public void initialize() {
     shooter.setFlywheelPower(0);
-    shooter.setHoodPower(0);
+    //    shooter.setHoodPower(0);
   }
+
+  // double k;
+
+  //0.1  1375
+  //0.25 4775
+  //0.5  10350
+  //0.75 15390
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
@@ -45,9 +52,25 @@ public class ShooterControls extends CommandBase {
     //   OI.operatorController.setRumble(RumbleType.kRightRumble, 0.5);
     // }
     //flywheelPower = 0.01 * OI.operatorController.getRawAxis(3);
-    hoodPower = MathUtil.clamp(OI.operatorController.getRawAxis(1) * 0.1, -0.05, 0.05);
+
+    // if (OI.operatorController.getXButtonPressed()) {
+    //   k += 1;}
+    // if (OI.operatorController.getYButtonPressed()) {
+    //   k -= 1;}
+
+    // hoodPower = MathUtil.clamp(OI.operatorController.getRawAxis(1), -0.05, 0.05);
+
     //    shooter.setFlywheelPower(flywheelPower);
-    shooter.setHoodPosition(shooter.minHoodPosition + 2.0 * Math.PI);
+
+    flywheelPower = 0.75 * OI.operatorController.getRawAxis(3);
+    shooter.setFlywheelPower(flywheelPower);
+    shooter.setHoodAngle(30.0 * Math.PI / 180.0);
+
+    // shooter.setHoodAngle((shooter.hoodAngleLow + shooter.hoodAngleHigh) * 0.5
+    //     + (shooter.hoodAngleLow - shooter.hoodAngleHigh) * 0.4 * OI.operatorController.getRawAxis(1));
+
+    // shooter.setHoodPosition((shooter.minHoodPosition + shooter.maxHoodPosition) * 0.5
+    //     + (shooter.maxHoodPosition - shooter.minHoodPosition) * 0.4 * OI.operatorController.getRawAxis(1));
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/TurretControls.java
+++ b/src/main/java/frc/robot/commands/TurretControls.java
@@ -6,19 +6,19 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.subsystems.Magazine;
+import frc.robot.subsystems.Turret;
 import frc.robot.subsystems.OI;
 
-public class MagazineControls extends CommandBase {
+public class TurretControls extends CommandBase {
 
-  private Magazine magazine;
-  private double magazineVelocity;
+  private Turret turret;
+  private double turretVelocity;
 
   /** Creates a new MagazineControls. */
-  public MagazineControls(Magazine magazine) {
-    this.magazine = magazine;
+  public TurretControls(Turret turret) {
+    this.turret = turret;
     // Use addRequirements() here to declare subsystem dependencies.
-    addRequirements(magazine);
+    addRequirements(turret);
   }
 
   // Called when the command is initially scheduled.
@@ -30,9 +30,9 @@ public class MagazineControls extends CommandBase {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    magazineVelocity = OI.operatorController.getRawAxis(2);
+    turretVelocity = 0.5 * OI.operatorController.getRawAxis(4);
     //SmartDashboard.putNumber("Magazine Power", magazineVelocity);
-    magazine.setVelocity(magazineVelocity);
+    turret.setVelocity(turretVelocity);
     // magazine.setVelocity(magazineVelocity);
   }
 

--- a/src/main/java/frc/robot/commands/TurretControls.java
+++ b/src/main/java/frc/robot/commands/TurretControls.java
@@ -6,13 +6,14 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpiutil.math.MathUtil;
 import frc.robot.subsystems.Turret;
 import frc.robot.subsystems.OI;
 
 public class TurretControls extends CommandBase {
 
   private Turret turret;
-  private double turretVelocity;
+  private double turretPower;
 
   /** Creates a new MagazineControls. */
   public TurretControls(Turret turret) {
@@ -30,9 +31,13 @@ public class TurretControls extends CommandBase {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    turretVelocity = 0.5 * OI.operatorController.getRawAxis(4);
+    turretPower = 0.5 * OI.operatorController.getRawAxis(4);
+      // turretPower = 0;
+      // if (Math.abs(OI.operatorController.getRawAxis(4)) > 0.2) {
+      //   turretPower = 0.75 * Math.signum(OI.operatorController.getRawAxis(4));
+      // }
     //SmartDashboard.putNumber("Magazine Power", magazineVelocity);
-    turret.setVelocity(turretVelocity);
+    turret.setPower(turretPower);
     // magazine.setVelocity(magazineVelocity);
   }
 

--- a/src/main/java/frc/robot/subsystems/Collector.java
+++ b/src/main/java/frc/robot/subsystems/Collector.java
@@ -79,6 +79,17 @@ public class Collector extends SubsystemBase {
     return isDeployed;
   }
 
+  /// Is the collector deployed?
+  public void raise() {
+    collectorDeployPneumatic.set(true);
+    collectorWithdrawPneumatic.set(false);
+  }
+
+  public void lower() {
+    collectorDeployPneumatic.set(false);
+    collectorWithdrawPneumatic.set(true);
+  }
+  
   /**
    * Are both pneumatics off?
    * 

--- a/src/main/java/frc/robot/subsystems/Magazine.java
+++ b/src/main/java/frc/robot/subsystems/Magazine.java
@@ -106,7 +106,7 @@ public class Magazine extends SubsystemBase {
         magazineMotor.getSelectedSensorVelocity());
     SmartDashboard.putNumber("Magazine Target Velocity [MAG]", magazineVelocity);
     SmartDashboard.putNumber("Magazine Position [MAG]", magazineMotor.getSelectedSensorPosition());
-    SmartDashboard.putNumber("Magazine Power [MAG]", magazineMotor.get());
+    SmartDashboard.putNumber("Magazine Power [MAG]", magazineMotor.getOutputCurrent());
     SmartDashboard.putNumber("Magazine Error [MAG]", magazineMotor.getClosedLoopError());
   }
 }

--- a/src/main/java/frc/robot/subsystems/Magazine.java
+++ b/src/main/java/frc/robot/subsystems/Magazine.java
@@ -106,7 +106,7 @@ public class Magazine extends SubsystemBase {
         magazineMotor.getSelectedSensorVelocity());
     SmartDashboard.putNumber("Magazine Target Velocity [MAG]", magazineVelocity);
     SmartDashboard.putNumber("Magazine Position [MAG]", magazineMotor.getSelectedSensorPosition());
-    SmartDashboard.putNumber("Magazine Power [MAG]", magazineMotor.getOutputCurrent());
+    SmartDashboard.putNumber("Magazine Power [MAG]", magazineMotor.getMotorOutputPercent());
     SmartDashboard.putNumber("Magazine Error [MAG]", magazineMotor.getClosedLoopError());
   }
 }

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -48,7 +48,7 @@ public class Shooter extends SubsystemBase {
   private final double flywheelTicksPerRevolution = 2048;
   private final int hoodEncoderTPR = 4096;
   public final double minHoodPosition = 0;
-  public final double maxHoodPosition = 16.306 * 2.0 * Math.PI;
+  public final double maxHoodPosition = 16.306;// * 2.0 * Math.PI;
 //  private final double minAngle = 19.64 * Math.PI / 180;
 //  private final double maxAngle = 49.18 * Math.PI / 180;
 

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -1,70 +1,140 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import com.ctre.phoenix.ErrorCode;
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.FeedbackDevice;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import com.revrobotics.*;
+import com.revrobotics.CANSparkMax.IdleMode;
+import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
 public class Shooter extends SubsystemBase {
+  private WPI_TalonFX shooterFlywheel1;
+  private WPI_TalonFX shooterFlywheel2;
+  private CANSparkMax hood;
+  private CANEncoder hoodHallSensor;
+  private CANEncoder hoodEncoder;
+  private CANPIDController hoodController;
 
-    public Shooter() {
+  private double flywheelP = 1.9e-1;
+  private double flywheelI = 0;
+  private double flywheelD = 0;
+  private double flywheelF = 0;
+  
+  private double hoodP_HSensor = 1.8e-1;
+  private double hoodI_HSensor = 4e-5;
+  private double hoodD_HSensor = 0;
+  private double hoodF_HSensor = 0;
 
+  private double hoodP_External = 2e-2;
+  private double hoodI_External = 0;
+  private double hoodD_External = 0;
+  private double hoodF_External = 0;
+  
+  double[] flywheelTemperatures;
+
+  private final double flywheelTicksPerRevolution = 2048;
+  private final int hoodEncoderTPR = 4096;
+  private final double minAngle = 19.64 * Math.PI / 180;
+  private final double maxAngle = 49.18 * Math.PI / 180;
+  public final double kRawMotorRange = 2.523808240890503;
+  public final double kMotorRadiansPerHoodRadian = kRawMotorRange * 2 * Math.PI / (maxAngle - minAngle);
+  private boolean usingExternalHoodEncoder = false;
+
+  public Shooter() {
+    shooterFlywheel1 = new WPI_TalonFX(22);
+    shooterFlywheel2 = new WPI_TalonFX(23);
+
+    shooterFlywheel1.configFactoryDefault();
+    shooterFlywheel2.configFactoryDefault();
+
+    shooterFlywheel2.follow(shooterFlywheel2);
+
+    //If the second flywheel motor *isn't* inverted, that would be pretty bad.
+    //Like, 'the flywheel tears itself apart' kind of bad.
+    shooterFlywheel1.setInverted(false);
+    shooterFlywheel2.setInverted(true);
+
+    shooterFlywheel1.setSafetyEnabled(false);
+    shooterFlywheel2.setSafetyEnabled(false);
+
+    shooterFlywheel1.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 20, 20, 0.1));
+    shooterFlywheel2.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 20, 20, 0.1));
+
+    shooterFlywheel1.setNeutralMode(NeutralMode.Brake);
+    shooterFlywheel2.setNeutralMode(NeutralMode.Brake);
+
+    shooterFlywheel1.configSelectedFeedbackSensor(FeedbackDevice.IntegratedSensor);
+
+    shooterFlywheel1.setSelectedSensorPosition(0);
+    shooterFlywheel1.setIntegralAccumulator(0);
+    shooterFlywheel1.configClosedloopRamp(0.25);
+
+    shooterFlywheel1.config_kP(0, flywheelP);
+    shooterFlywheel1.config_kI(0, flywheelI);
+    shooterFlywheel1.config_kD(0, flywheelD);
+    shooterFlywheel1.config_kF(0, flywheelF);
+
+    hood = new CANSparkMax(25, MotorType.kBrushless);
+    hood.clearFaults();
+    hood.restoreFactoryDefaults();
+    hood.setIdleMode(IdleMode.kBrake);
+    hood.setInverted(false);
+
+    hoodHallSensor = hood.getEncoder(EncoderType.kHallSensor, 1);
+    hoodHallSensor.setPosition(0);
+
+    hoodEncoder = hood.getAlternateEncoder(AlternateEncoderType.kQuadrature, hoodEncoderTPR);
+    hoodEncoder.setPosition(0);
+    hoodEncoder.setInverted(true);
+
+    flywheelTemperatures = new double[] { -273.15, 15e6 };
+
+    hoodController = hood.getPIDController();
+    if (usingExternalHoodEncoder) {
+      hoodController.setFeedbackDevice(hoodEncoder);
+      hoodController.setP(hoodP_HSensor);
+      hoodController.setI(hoodI_HSensor);
+      hoodController.setD(hoodD_HSensor);
+      hoodController.setFF(hoodF_HSensor);
+    } else {
+      hoodController.setFeedbackDevice(hoodHallSensor);
+      hoodController.setP(hoodP_External);
+      hoodController.setI(hoodI_External);
+      hoodController.setD(hoodD_External);
+      hoodController.setFF(hoodF_External);
     }
+    hood.setClosedLoopRampRate(0.25);
+  }
 
-    /// Monitor current level of flywheel for 'spking' to:
-    public double getFlywheelCurrent() {
-      // TODO:
-      return 0.0;
-    }
+  /**
+   * Directly sets the power to the flywheel motors.
+   */
+  public void setFlywheelPower(double power) {
+    shooterFlywheel1.set(ControlMode.PercentOutput, power);   
+  }
 
-    public void setFlywheelVelocity(double velocity) {
-      // TODO:
-    }
+  /**
+   * Directly sets the power to the hood motor.
+   */
+  public void setHoodPower(double power) {
+    hood.set(power);
+  }
 
-    public double getFlywheelVelocity() {
-      // TODO:
-      return 0.0;
-    }
-
-    public double getHoodAngle() {
-      // TODO:
-      return 0.0;
-    }
-
-    // Set hood angle
-    public void setHoodAngle(double angle) {
-      // TODO:
-
-    }
-
-    // Return maximum hood angle.
-    public double getMaxHoodAngle() {
-      // TODO:
-      return 0.0;
-    }
-
-    // Return minimum hood angle.
-    public double getMinHoodAngle() {
-      // TODO:
-      return 0.0;
-    }
-
-    // Return deadzone turret
-    public double getDeadzoneCurrent() {
-      // TODO:
-      return 0.0;
-    }
-
-    public void setDeadzoneVelocity(double velocity) {
-      // TODO:
-    }
-
-    public double getDeadzoneVelocity() {
-      // TODO:
-      return 0.0;
-    }
-    
-
-    @Override
-    public void periodic() {
-      // This method will be called once per scheduler run
-    }
-    
+  @Override
+  public void periodic() {
+    flywheelTemperatures[0] = shooterFlywheel1.getTemperature();
+    flywheelTemperatures[1] = shooterFlywheel2.getTemperature();
+    // This method will be called once per scheduler run
+  }
 }

--- a/src/main/java/frc/robot/subsystems/Turret.java
+++ b/src/main/java/frc/robot/subsystems/Turret.java
@@ -30,7 +30,9 @@ public class Turret extends SubsystemBase {
         System.out.println("[Magazine] Error: Turret motor (CAN ID 24) cannot find encoder (Error code: "
             + turretEncoderAttached.value + ").");
       }
+    
       setPIDF();
+      
     }
 
     /// Returns the accumulated position of the turret in radians.
@@ -49,6 +51,10 @@ public class Turret extends SubsystemBase {
       turretRotator.set(ControlMode.Velocity, turretVelocity);
     }
 
+    /// Directly sets the power of the turret motor.
+    public void setPower(double power) {
+      turretRotator.set(ControlMode.PercentOutput, power);
+    }
 
     @Override
     public void periodic() {

--- a/src/main/java/frc/robot/subsystems/Turret.java
+++ b/src/main/java/frc/robot/subsystems/Turret.java
@@ -1,15 +1,74 @@
 package frc.robot.subsystems;
 
+import com.ctre.phoenix.ErrorCode;
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.FeedbackDevice;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Turret extends SubsystemBase {
 
+    private WPI_TalonSRX turretRotator;
+    private double P = 0;
+    private double I = 0;
+    private double D = 0;
+    private double F = 0;
+    private double turretVelocity;
+    private double turretTicksPerRadian = 6441.318;
+
     public Turret() {
-        
+      turretRotator = new WPI_TalonSRX(24);
+      turretRotator.configFactoryDefault();
+      turretRotator.setSafetyEnabled(false);
+      turretRotator.setNeutralMode(NeutralMode.Brake);
+      ErrorCode turretEncoderAttached = turretRotator
+          .configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, 0, 0);
+      if (turretEncoderAttached.value != 0) {
+        System.out.println("[Magazine] Error: Turret motor (CAN ID 24) cannot find encoder (Error code: "
+            + turretEncoderAttached.value + ").");
+      }
+      setPIDF();
     }
+
+    /// Returns the accumulated position of the turret in radians.
+    public double getPosition() {
+      return turretRotator.getSelectedSensorPosition(0) / turretTicksPerRadian;
+    }
+
+    /// Returns the velocity of the turret in radians/second.
+    public double getVelocity() {
+      return turretRotator.getSelectedSensorVelocity(0) * 10.0 / turretTicksPerRadian;
+    }
+
+    /// Sets the velocity of the turret in radians/second.
+    public void setVelocity(double angularVelocity) {
+      turretVelocity = angularVelocity * turretTicksPerRadian * 0.1;
+      turretRotator.set(ControlMode.Velocity, turretVelocity);
+    }
+
 
     @Override
     public void periodic() {
-      // This method will be called once per scheduler run
+      SmartDashboard.putNumber("Turret Velocity [TURRET]",
+      turretRotator.getSelectedSensorVelocity());
+      SmartDashboard.putNumber("Turret Target Velocity [TURRET]", turretVelocity);
+      SmartDashboard.putNumber("Turret Position (raw) [TURRET]", turretRotator.getSelectedSensorPosition());
+      SmartDashboard.putNumber("Turret Power (raw) [TURRET]", turretRotator.getMotorOutputPercent());
+      SmartDashboard.putNumber("Turret Error (raw) [TURRET]", turretRotator.getClosedLoopError());
+      SmartDashboard.putNumber("Turret Position (radians) [TURRET]",
+          turretRotator.getSelectedSensorPosition(0) / turretTicksPerRadian);
+      SmartDashboard.putNumber("Turret Velocity (radians/s) [TURRET]",
+          turretRotator.getSelectedSensorVelocity(0) * 10.0 / turretTicksPerRadian);
     }
+
+    public void setPIDF() {
+      turretRotator.config_kP(0, P);
+      turretRotator.config_kI(0, I);
+      turretRotator.config_kD(0, D);
+      turretRotator.config_kF(0, F);
+    }
+  
 }

--- a/vendordeps/REVRobotics.json
+++ b/vendordeps/REVRobotics.json
@@ -1,0 +1,73 @@
+{
+    "cppDependencies": [
+        {
+            "artifactId": "SparkMax-cpp",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "SparkMax",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "1.5.4"
+        },
+        {
+            "artifactId": "SparkMax-driver",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "SparkMaxDriver",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "1.5.4"
+        }
+    ],
+    "fileName": "REVRobotics.json",
+    "javaDependencies": [
+        {
+            "artifactId": "SparkMax-java",
+            "groupId": "com.revrobotics.frc",
+            "version": "1.5.4"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "artifactId": "SparkMax-driver",
+            "groupId": "com.revrobotics.frc",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ],
+            "version": "1.5.4"
+        }
+    ],
+    "jsonUrl": "http://www.revrobotics.com/content/sw/max/sdk/REVRobotics.json",
+    "mavenUrls": [
+        "http://www.revrobotics.com/content/sw/max/sdk/maven/"
+    ],
+    "name": "REVRobotics",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "version": "1.5.4"
+}


### PR DESCRIPTION
The turret and shooter mechanisms are both controllable, and have their own respective teleop commands. The turret and hood are only able to move within the safe range of angles, and they also are both able to return their absolute angles. The turret and flywheel do not have PIDF control yet, but there are feedforward constants for both of them, so PID tuning should not be too diffficult. The hood has closed-loop position control, and can be moved to a given angle within its range.