### PR TITLE
Added the ability to switch between the InterpolationTables for the small and large power port 

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -23,7 +23,7 @@ public final class Constants {
         LOW,HIGH
     };
 
-    public static PowerPortConfiguration portConfig;
+    public static final PowerPortConfiguration portConfig = PowerPortConfiguration.LOW;
 
     /**Power cell diameter in meters.**/
     public static final double POWER_CELL_DIAMETER = 0.18;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -15,8 +15,15 @@ package frc.robot;
  * wherever the constants are needed, to reduce verbosity.
  */
 public final class Constants {
+
     public static final double CONTROLLER_DEADZONE = 0.06;
     public static final double THROTTLE_FALLOFF = 0.7;
+
+    public enum PowerPortConfiguration {
+        LOW,HIGH
+    };
+
+    public static PowerPortConfiguration portConfig;
 
     /**Power cell diameter in meters.**/
     public static final double POWER_CELL_DIAMETER = 0.18;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -48,6 +48,7 @@ import frc.robot.commands.TurretPortAlignCommand;
 import frc.robot.commands.TurretPositionCommand;
 import frc.robot.commands.WaitForTarget;
 import frc.robot.commands.WaitToFire;
+import frc.robot.Constants.PowerPortConfiguration;
 import frc.robot.Utility.PathBuilder.PathIndex;
 // Import commands: Add commands here.
 import frc.robot.commands.AdvanceMagazineCommand;
@@ -126,6 +127,9 @@ public class RobotContainer {
     turret.setDefaultCommand(teleTurret);
     collector.setDefaultCommand(teleCollect);
     shooter.setDefaultCommand(teleShooter);
+
+    //DO NOT REMOVE THIS OR EVERYONE WILL DIE
+    Constants.portConfig = PowerPortConfiguration.LOW;
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -393,9 +393,11 @@ public class RobotContainer {
               new TurretPortAlignCommand(turret, portTracker)
             )
           ),
-          new AdvanceMagazineCommand(magazine, 1.25, 3),
+          new AdvanceMagazineCommand(magazine, 0.9, 1.85),
           new WaitCommand(1.0),
-          new AdvanceMagazineCommand(magazine, 1.25, 3),
+          new AdvanceMagazineCommand(magazine, 0.9, 1.4),
+          new WaitCommand(1.0),
+          new AdvanceMagazineCommand(magazine, 0.9, 1.85),
           new SequentialCommandGroup(
             new TurretPositionCommand(turret, 0),
             new ShooterSetCommand(shooter, shooter.hoodAngleHigh, 0)

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -373,6 +373,34 @@ public class RobotContainer {
             new PurePursuit(drivetrain, Utility.PathBuilder.getPath(PathIndex.BARREL_3), 0, 0),
             new PurePursuit(drivetrain, Utility.PathBuilder.getPath(PathIndex.BARREL_4), 0, 0)
           );
+      case 12:
+        System.out.println("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n!!!!!!!!");
+        return 
+        new SequentialCommandGroup(
+          new SequentialCommandGroup(
+            // new InstantCommand(shooter::interruptCurrentCommand, shooter),
+            // new InstantCommand(shooter::stop, shooter),
+            new InstantCommand(shooter::lowerHood, shooter),
+            new ParallelDeadlineGroup(
+              new SequentialCommandGroup(
+                new WaitToFire(shooter, portTracker),
+                new TargetHoodCommand(shooter, portTracker)
+              ),
+              new SequentialCommandGroup(
+                new WaitForTarget(portTracker),
+                new TargetFlywheelCommand(shooter, portTracker)
+              ),
+              new TurretPortAlignCommand(turret, portTracker)
+            )
+          ),
+          new AdvanceMagazineCommand(magazine, 1.25, 3),
+          new WaitCommand(1.0),
+          new AdvanceMagazineCommand(magazine, 1.25, 3),
+          new SequentialCommandGroup(
+            new TurretPositionCommand(turret, 0),
+            new ShooterSetCommand(shooter, shooter.hoodAngleHigh, 0)
+          )
+        );  
       default:
         return new TurnCommand(drivetrain, bling, 0.0);
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -127,9 +127,6 @@ public class RobotContainer {
     turret.setDefaultCommand(teleTurret);
     collector.setDefaultCommand(teleCollect);
     shooter.setDefaultCommand(teleShooter);
-
-    //DO NOT REMOVE THIS OR EVERYONE WILL DIE
-    Constants.portConfig = PowerPortConfiguration.LOW;
   }
 
   /**

--- a/src/main/java/frc/robot/ShuffleboardWidgets.java
+++ b/src/main/java/frc/robot/ShuffleboardWidgets.java
@@ -27,9 +27,21 @@ public class ShuffleboardWidgets extends SubsystemBase {
         public static int auto = 100;
         private byte autoNum = 12;
         private byte place = -1;
-        private String[] autoNames = { "1CellScan&Collect", "2CellScan&Collect", "3CellScan&Collect", "Squaretest",
-                        "DriveTPoint", "AutoFire", "GalaxySearchSlow", "ConditionalCommandTest", "Drove&TurnToHeading",
-                        "AutonomousAwardAwfulness", "GalaxySearchFast", "PurePursuitBarrel"};
+        private String[] autoNames = {
+                "1CellScan&Collect",
+                "2CellScan&Collect",
+                "3CellScan&Collect",
+                "Squaretest",
+                "DriveTPoint",
+                "AutoFire",
+                "GalaxySearchSlow",
+                "ConditionalCommandTest",
+                "Drove&TurnToHeading",
+                "AutonomousAwardAwfulness",
+                "GalaxySearchFast",
+                "PurePursuitBarrel",
+                "FireTwoPowerCells"
+        };
 
         private static ShuffleboardLayout autoChooser;
         private static ShuffleboardLayout driving;
@@ -49,7 +61,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private PowerCellTracker cellTracker;
         private PowerPortTracker portTracker;
 
-        private boolean[] autos = new boolean[autoNum];
+        private boolean[] autos;
 
         private ChassisSpeeds chassis = new ChassisSpeeds();
         private Pose2d pose = new Pose2d();
@@ -85,7 +97,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private int portX = 0;
         private int portY = 0;
 
-        private NetworkTableEntry[] autosE = new NetworkTableEntry[autoNum];
+        private NetworkTableEntry[] autosE;
 
         private NetworkTableEntry robotAngE;
         private NetworkTableEntry robotAngleE;
@@ -131,7 +143,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 this.shooter = shooter;
                 this.cellTracker = cellTracker;
                 this.portTracker = portTracker;
-
+                autoNum = (byte) autoNames.length;
+                autos = new boolean[autoNum];
+                autosE = new NetworkTableEntry[autoNum];
         }
 
         public void initialize() {
@@ -149,8 +163,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 shooting = tab.getLayout("Shooter", BuiltInLayouts.kList).withSize(1, 3).withPosition(4, 2);
                 cellTracking = tab.getLayout("CellTracker", BuiltInLayouts.kList).withSize(1, 2).withPosition(3, 0);
                 portTracking = tab.getLayout("PortTracker", BuiltInLayouts.kList).withSize(1, 2).withPosition(4, 0);
-                shootingReadout = tab.getLayout("Shooter readouts", BuiltInLayouts.kList).withSize(2, 5).withPosition(5,
-                                0);
+                shootingReadout = tab.getLayout("Shooter readouts", BuiltInLayouts.kList).withSize(2, 5).withPosition(5,0);
 
                 hoodMax = shooter.maxHoodPosition;
                 hoodMin = shooter.minHoodPosition;
@@ -167,6 +180,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
 
         private void createWidgets() {
                 for (byte i = 0; i < autoNum; i++) {
+                        System.out.println(i + "," + autoNum);
                         autosE[i] = autoChooser.add(autoNames[i], autos[i]).withWidget(BuiltInWidgets.kToggleSwitch)
                                         .getEntry();
                 }

--- a/src/main/java/frc/robot/ShuffleboardWidgets.java
+++ b/src/main/java/frc/robot/ShuffleboardWidgets.java
@@ -25,7 +25,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private static ShuffleboardTab tab;
         // private static NetworkTableEntry chooseAuto;
         public static int auto = 100;
-        private byte autoNum = 12;
+        private byte autoNum = 13;
         private byte place = -1;
         private String[] autoNames = {
                 "1CellScan&Collect",
@@ -40,7 +40,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 "AutonomousAwardAwfulness",
                 "GalaxySearchFast",
                 "PurePursuitBarrel",
-                "FireTwoPowerCells"
+                "FireThreePowerCells"
         };
 
         private static ShuffleboardLayout autoChooser;
@@ -61,7 +61,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private PowerCellTracker cellTracker;
         private PowerPortTracker portTracker;
 
-        private boolean[] autos;
+        private boolean[] autos = new boolean[autoNum];
 
         private ChassisSpeeds chassis = new ChassisSpeeds();
         private Pose2d pose = new Pose2d();
@@ -87,6 +87,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private double hoodPosition = 0.0;
         private double hoodMin = 0.0;
         private double hoodMax = 0.0;
+        private double flywheelTemp1 = 0.0;
+        private double flywheelTemp2 = 0.0;
+        private double hoodMotorCurrent = 0.0;
 
         private PowerCellData cellData = new PowerCellData();
         private int cellX = 0;
@@ -97,7 +100,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private int portX = 0;
         private int portY = 0;
 
-        private NetworkTableEntry[] autosE;
+        private NetworkTableEntry[] autosE = new NetworkTableEntry[autoNum];
 
         private NetworkTableEntry robotAngE;
         private NetworkTableEntry robotAngleE;
@@ -121,6 +124,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private NetworkTableEntry hoodPositionE;
         private NetworkTableEntry hoodMinE;
         private NetworkTableEntry hoodMaxE;
+        private NetworkTableEntry flywheelTemp1E;
+        private NetworkTableEntry flywheelTemp2E;
+        private NetworkTableEntry hoodMotorCurrentE;
 
         private NetworkTableEntry cellXE;
         private NetworkTableEntry cellYE;
@@ -180,7 +186,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
 
         private void createWidgets() {
                 for (byte i = 0; i < autoNum; i++) {
-                        System.out.println(i + "," + autoNum);
+                        //System.out.println(i + "," + autoNum);
                         autosE[i] = autoChooser.add(autoNames[i], autos[i]).withWidget(BuiltInWidgets.kToggleSwitch)
                                         .getEntry();
                 }
@@ -212,6 +218,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 hoodPositionE = shooting.add("Position", hoodPosition).getEntry();
                 hoodMinE = shooting.add("Min P", hoodMin).getEntry();
                 hoodMaxE = shooting.add("Max P", hoodMax).getEntry();
+                flywheelTemp1E = shooting.add("Flyw. Temp 1", flywheelTemp1).getEntry();
+                flywheelTemp2E = shooting.add("Flyw. Temp 2", flywheelTemp2).getEntry();
+                hoodMotorCurrentE = shooting.add("Hood Mtr Current", hoodMotorCurrent).getEntry();
 
                 cellXE = cellTracking.add("X", cellX).getEntry();
                 cellYE = cellTracking.add("Y", cellY).getEntry();
@@ -262,6 +271,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 flywheelVelocity = shooter.getFlywheelVelocity();
                 hoodAngle = Units.radiansToDegrees(shooter.getHoodAngle());
                 hoodPosition = shooter.getHoodPosition();
+                flywheelTemp1 = shooter.getFlywheelTemperatures()[0];
+                flywheelTemp2 = shooter.getFlywheelTemperatures()[1];
+                hoodMotorCurrent = shooter.getHoodMotorCurrent();
 
                 cellTracker.getCellData(cellData);
                 cellX = cellData.cx;
@@ -292,6 +304,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 flywheelVelocityE.setDouble(flywheelVelocity);
                 hoodAngleE.setDouble(hoodAngle);
                 hoodPositionE.setDouble(hoodPosition);
+                flywheelTemp1E.setDouble(flywheelTemp1);
+                flywheelTemp2E.setDouble(flywheelTemp2);
+                hoodMotorCurrentE.setDouble(hoodMotorCurrent);
 
                 cellXE.setNumber(cellX);
                 cellYE.setNumber(cellY);

--- a/src/main/java/frc/robot/commands/TargetFlywheelCommand.java
+++ b/src/main/java/frc/robot/commands/TargetFlywheelCommand.java
@@ -72,22 +72,23 @@ public class TargetFlywheelCommand extends CommandBase {
       flywheelTable = flywheelTableHigh;
     }
 
-
-      // new InterpolatorTableEntry(1.5,343.75),
-      // new InterpolatorTableEntry(1.759,343.75),
-      // new InterpolatorTableEntry(2.609,375),
-      // new InterpolatorTableEntry(3.34,360.1),
-      // new InterpolatorTableEntry(4.76,430),
-      // new InterpolatorTableEntry(5.019,467.8),
-      // new InterpolatorTableEntry(6.52,503.5),
-      // new InterpolatorTableEntry(8.25,531.25),
-      // new InterpolatorTableEntry(8.7,562.5)
+    
+    // new InterpolatorTableEntry(1.5,343.75),
+    // new InterpolatorTableEntry(1.759,343.75),
+    // new InterpolatorTableEntry(2.609,375),
+    // new InterpolatorTableEntry(3.34,360.1),
+    // new InterpolatorTableEntry(4.76,430),
+    // new InterpolatorTableEntry(5.019,467.8),
+    // new InterpolatorTableEntry(6.52,503.5),
+    // new InterpolatorTableEntry(8.25,531.25),
+    // new InterpolatorTableEntry(8.7,562.5)
     // new InterpolatorTableEntry(1.79, 281.25), new InterpolatorTableEntry(2.35, 343.75),
-        // new InterpolatorTableEntry(3.05, 343.75), new InterpolatorTableEntry(3.54, 375),
-        // new InterpolatorTableEntry(3.97, 406.25), new InterpolatorTableEntry(4.56, 437.3),
-        // new InterpolatorTableEntry(5.02, 437.3), new InterpolatorTableEntry(5.51, 468.75),
-        // new InterpolatorTableEntry(6.03, 468.75), new InterpolatorTableEntry(6.51, 468.75));
+    // new InterpolatorTableEntry(3.05, 343.75), new InterpolatorTableEntry(3.54, 375),
+    // new InterpolatorTableEntry(3.97, 406.25), new InterpolatorTableEntry(4.56, 437.3),
+    // new InterpolatorTableEntry(5.02, 437.3), new InterpolatorTableEntry(5.51, 468.75),
+    // new InterpolatorTableEntry(6.03, 468.75), new InterpolatorTableEntry(6.51, 468.75));
     shooter = shooter_;
+    portTracker = portTracker_;
     currentFlywheelVelocity = 0;
     flywheelVelocity = 0;
     range = 0;

--- a/src/main/java/frc/robot/commands/TargetFlywheelCommand.java
+++ b/src/main/java/frc/robot/commands/TargetFlywheelCommand.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.PowerPortTracker;
 import frc.robot.subsystems.Shooter;
 import frc.robot.Constants;
+import frc.robot.Constants.PowerPortConfiguration;
 import frc.robot.components.InterpolatorTable;
 import frc.robot.components.InterpolatorTable.InterpolatorTableEntry;
 
@@ -24,6 +25,25 @@ public class TargetFlywheelCommand extends CommandBase {
   double currentFlywheelVelocity;
   double range;
 
+  /**Table for shooting in the gym, or anywhere else with the full-size power port.**/
+  InterpolatorTable flywheelTableHigh = new InterpolatorTable(
+    new InterpolatorTableEntry(1.6, 332.0),
+    new InterpolatorTableEntry(1.8, 348.0),
+    new InterpolatorTableEntry(3.48, 410.1),
+    new InterpolatorTableEntry(4.86, 509.8),
+    new InterpolatorTableEntry(6.18,527.15)
+  );
+
+  /**Table for shooting in 107, or anywhere else with the small power port.**/
+  InterpolatorTable flywheelTableLow = new InterpolatorTable(
+    new InterpolatorTableEntry(1.79, 281.25), new InterpolatorTableEntry(2.35, 343.75),
+    new InterpolatorTableEntry(3.05, 343.75), new InterpolatorTableEntry(3.54, 375),
+    new InterpolatorTableEntry(3.97, 406.25), new InterpolatorTableEntry(4.56, 437.3),
+    new InterpolatorTableEntry(5.02, 437.3), new InterpolatorTableEntry(5.51, 468.75),
+    new InterpolatorTableEntry(6.03,468.75),new InterpolatorTableEntry(6.51,468.75)
+  );
+  
+
   boolean hasValidRangeData;
 
   int numLoops;
@@ -35,7 +55,7 @@ public class TargetFlywheelCommand extends CommandBase {
   public static final double acceptableVelocityDifference = Constants.ACCEPTABLE_FLYWHEEL_VELOCITY_DIFFERENCE;
   
   InterpolatorTable flywheelTable;
-  
+
   /**
    * Uses the range sensor to set the flywheel speed.
    * @param shooter_ The shooter subsystem
@@ -44,16 +64,14 @@ public class TargetFlywheelCommand extends CommandBase {
    * @param acceptableVelocityDifference_ How close (in radians/sec difference) the flywheel velocity should be to the target flyhweel velocity before the command ends (defaults to 1 radian/sec).
    */
   public TargetFlywheelCommand(Shooter shooter_, PowerPortTracker portTracker_, int rangeUpdatePeriod_, double acceptableVelocityDifference_) {
-    portTracker = portTracker_;
     rangeUpdatePeriod = rangeUpdatePeriod_;
-    flywheelTable = new InterpolatorTable(
-      new InterpolatorTableEntry(1.6, 332.0),
-      new InterpolatorTableEntry(1.8, 348.0),
-      new InterpolatorTableEntry(3.48, 410.1),
-      new InterpolatorTableEntry(4.86, 509.8),
-     // new InterpolatorTableEntry(4.80, 494.2),
-     // new InterpolatorTableEntry(4.60, 449.4),
-      new InterpolatorTableEntry(6.18, 527.15)
+
+    if (Constants.portConfig == PowerPortConfiguration.LOW) {
+      flywheelTable = flywheelTableLow;
+    } else if (Constants.portConfig == PowerPortConfiguration.HIGH) {
+      flywheelTable = flywheelTableHigh;
+    }
+
 
       // new InterpolatorTableEntry(1.5,343.75),
       // new InterpolatorTableEntry(1.759,343.75),
@@ -64,7 +82,6 @@ public class TargetFlywheelCommand extends CommandBase {
       // new InterpolatorTableEntry(6.52,503.5),
       // new InterpolatorTableEntry(8.25,531.25),
       // new InterpolatorTableEntry(8.7,562.5)
-    );
     // new InterpolatorTableEntry(1.79, 281.25), new InterpolatorTableEntry(2.35, 343.75),
         // new InterpolatorTableEntry(3.05, 343.75), new InterpolatorTableEntry(3.54, 375),
         // new InterpolatorTableEntry(3.97, 406.25), new InterpolatorTableEntry(4.56, 437.3),

--- a/src/main/java/frc/robot/commands/TargetHoodCommand.java
+++ b/src/main/java/frc/robot/commands/TargetHoodCommand.java
@@ -10,6 +10,7 @@ import frc.robot.subsystems.PowerPortTracker;
 import frc.robot.subsystems.Shooter;
 import frc.robot.subsystems.PowerPortTracker.PowerPortData;
 import frc.robot.Constants;
+import frc.robot.Constants.PowerPortConfiguration;
 import frc.robot.components.InterpolatorTable;
 import frc.robot.components.InterpolatorTable.InterpolatorTableEntry;
 
@@ -33,6 +34,24 @@ public class TargetHoodCommand extends CommandBase {
 
   boolean readyToFire;
 
+  /**Table for shooting in the gym, or anywhere else with the full-size power port.**/
+  InterpolatorTable hoodTableHigh = new InterpolatorTable(
+    new InterpolatorTableEntry(1.6, 0.675),
+    new InterpolatorTableEntry(1.8, 0.644),
+    new InterpolatorTableEntry(3.48, 0.515),
+    new InterpolatorTableEntry(4.86, 0.373),
+    new InterpolatorTableEntry(6.18, 0.355)
+  );
+
+  /**Table for shooting in 107, or anywhere else with the small power port.**/
+  InterpolatorTable hoodTableLow = new InterpolatorTable(
+    new InterpolatorTableEntry(1.79, 0.658353), new InterpolatorTableEntry(2.35, 0.483353),
+    new InterpolatorTableEntry(3.05, 0.483353), new InterpolatorTableEntry(3.54, 0.483353),
+    new InterpolatorTableEntry(3.97, 0.408353), new InterpolatorTableEntry(4.56, 0.363353),
+    new InterpolatorTableEntry(5.02, 0.358353), new InterpolatorTableEntry(5.51, 0.367783),
+    new InterpolatorTableEntry(6.03, 0.367783), new InterpolatorTableEntry(6.51, 0.34278)
+  );
+
   /**
    * Moves the hood to a position based on the range sensor.
    * @param shooter_ The shooter subsystem
@@ -45,27 +64,27 @@ public class TargetHoodCommand extends CommandBase {
 
     requiredValidRangeCount = requiredValidRangeCount_;
 
-    hoodTable = new InterpolatorTable(
-        new InterpolatorTableEntry(1.6, 0.675),
-       new InterpolatorTableEntry(1.8, 0.644),
-        new InterpolatorTableEntry(3.48, 0.515),
-        new InterpolatorTableEntry(4.86, 0.373),
-      //new InterpolatorTableEntry(1.65, 0.661),
-      //new InterpolatorTableEntry(3.26, 0.557),
-      //new InterpolatorTableEntry(4.80, 0.355),
-      // new InterpolatorTableEntry(4.60, 0.447),
-      new InterpolatorTableEntry(6.18, 0.355)
+    if (Constants.portConfig == PowerPortConfiguration.LOW) {
+      hoodTable = hoodTableLow;
+    } else if (Constants.portConfig == PowerPortConfiguration.HIGH) {
+      hoodTable = hoodTableHigh;
+    }
 
-      // new InterpolatorTableEntry(1.5,0.732),
-      // new InterpolatorTableEntry(1.759,0.708),
-      // new InterpolatorTableEntry(2.609,0.583),
-      // new InterpolatorTableEntry(3.34,0.583),
-      // new InterpolatorTableEntry(4.76,0.504),
-      // new InterpolatorTableEntry(5.02,0.41),
-      // new InterpolatorTableEntry(6.52,0.394),
-      // new InterpolatorTableEntry(8.25,0.408),
-      // new InterpolatorTableEntry(8.7,0.408)
-    );
+      //new InterpolatorTableEntry(1.65, 0.661),
+    //new InterpolatorTableEntry(3.26, 0.557),
+    //new InterpolatorTableEntry(4.80, 0.355),
+    // new InterpolatorTableEntry(4.60, 0.447),
+
+    // new InterpolatorTableEntry(1.5,0.732),
+    // new InterpolatorTableEntry(1.759,0.708),
+    // new InterpolatorTableEntry(2.609,0.583),
+    // new InterpolatorTableEntry(3.34,0.583),
+    // new InterpolatorTableEntry(4.76,0.504),
+    // new InterpolatorTableEntry(5.02,0.41),
+    // new InterpolatorTableEntry(6.52,0.394),
+    // new InterpolatorTableEntry(8.25,0.408),
+    // new InterpolatorTableEntry(8.7,0.408)
+      
       // new InterpolatorTableEntry(1.79, 0.658353), new InterpolatorTableEntry(2.35, 0.483353),
       // new InterpolatorTableEntry(3.05, 0.483353), new InterpolatorTableEntry(3.54, 0.483353),
       // new InterpolatorTableEntry(3.97, 0.408353), new InterpolatorTableEntry(4.56, 0.363353),

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -45,7 +45,9 @@ public class Shooter extends SubsystemBase {
 
   private double flywheelTargetVelocity = 0;
 
-  public double[] flywheelTemperatures;
+  private double[] flywheelTemperatures;
+
+  private double hoodMotorCurrent;
 
   private final double flywheelTicksPerRevolution = 2048;
   private final int hoodEncoderTPR = 4096;
@@ -152,6 +154,24 @@ public class Shooter extends SubsystemBase {
   }
 
   /**
+   * Gets the flywheel temperatures in Celsius
+   * 
+   * @return both flywheel motor's temperatures in Celsius
+   */
+  public double[] getFlywheelTemperatures() {
+    return flywheelTemperatures;
+  }
+
+  /**
+   * Gets the hood's motor's current in amperage
+   * 
+   * @return hood's current in amperage
+   */
+  public double getHoodMotorCurrent() {
+    return hoodMotorCurrent;
+  }
+
+  /**
    * Instantly stops the flywheel motor. Due to the PIDF loop
    * being tuned for high velocities, this may cause some oscillation.
    */
@@ -251,9 +271,7 @@ public class Shooter extends SubsystemBase {
   public void periodic() {
     flywheelTemperatures[0] = shooterFlywheel1.getTemperature();
     flywheelTemperatures[1] = shooterFlywheel2.getTemperature();
-  }
-  
-  public double[] getFlywheelTemperature() {
-    return flywheelTemperatures;
+    hoodMotorCurrent = hood.getOutputCurrent();
+    System.out.println("Flwheel current: " + shooterFlywheel1.getStatorCurrent());
   }
 }

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -272,6 +272,5 @@ public class Shooter extends SubsystemBase {
     flywheelTemperatures[0] = shooterFlywheel1.getTemperature();
     flywheelTemperatures[1] = shooterFlywheel2.getTemperature();
     hoodMotorCurrent = hood.getOutputCurrent();
-    System.out.println("Flwheel current: " + shooterFlywheel1.getStatorCurrent());
   }
 }


### PR DESCRIPTION
There's an enum variable in Constants.java that lets you switch between the two modes, and different InterpolationTables get loaded depending on which one you set. I've checked the code and it works (I would have merged this earlier but I thought we had already done that).