### PR TITLE
Updated interpolator tables and added in some warning indicators on Shuffleboard 

### DIFF
--- a/src/main/java/frc/robot/ShuffleboardWidgets.java
+++ b/src/main/java/frc/robot/ShuffleboardWidgets.java
@@ -128,6 +128,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private NetworkTableEntry flywheelVelocityE;
         private NetworkTableEntry flywheelTargetVelocityE;
         private NetworkTableEntry hoodAngleE;
+        private NetworkTableEntry hoodAngleRadiansE;
         private NetworkTableEntry hoodPositionE;
         private NetworkTableEntry hoodMinE;
         private NetworkTableEntry hoodMaxE;
@@ -143,7 +144,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private NetworkTableEntry portYE;
 
         private NetworkTableEntry shooterFlywheelSpeed;
-        private NetworkTableEntry shooterHoodAngle;
+        private NetworkTableEntry shooterHoodAngleDegrees;
         private NetworkTableEntry sensorRange;
         private NetworkTableEntry portTrackerHasData;
 
@@ -176,8 +177,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 shooting = tab.getLayout("Shooter", BuiltInLayouts.kList).withSize(1, 3).withPosition(4, 2);
                 cellTracking = tab.getLayout("CellTracker", BuiltInLayouts.kList).withSize(1, 2).withPosition(3, 0);
                 portTracking = tab.getLayout("PortTracker", BuiltInLayouts.kList).withSize(1, 2).withPosition(4, 0);
-                shootingReadout = tab.getLayout("Shooter readouts", BuiltInLayouts.kList).withSize(2, 5).withPosition(5,
-                                0);
+                shootingReadout = tab.getLayout("Shooter readouts", BuiltInLayouts.kList).withSize(2, 5).withPosition(5,0);
 
                 hoodMax = shooter.maxHoodPosition;
                 hoodMin = shooter.minHoodPosition;
@@ -223,8 +223,8 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 flywheelVelocityE = shooting.add("Velocity", flywheelVelocity).getEntry();
                 flywheelTargetVelocityE = shooting.add("Target Velocity", shooter.getFlywheelTargetVelocity())
                                 .getEntry();
-                hoodAngleE = shooting.add("Angle", hoodAngle).withWidget(BuiltInWidgets.kDial)
-                                .withProperties(Map.of("min", 0, "max", 180)).getEntry();
+                hoodAngleE = shooting.add("Angle", hoodAngle).withWidget(BuiltInWidgets.kNumberBar)
+                                .withProperties(Map.of("min", shooter.hoodAngleLow, "max", shooter.hoodAngleHigh)).getEntry();
                 hoodPositionE = shooting.add("Position", hoodPosition).getEntry();
                 hoodMinE = shooting.add("Min P", hoodMin).getEntry();
                 hoodMaxE = shooting.add("Max P", hoodMax).getEntry();
@@ -247,7 +247,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 sensorRange = shootingReadout.add("Range sensor distance (meters)", portTracker.getRange())
                                 .withWidget(BuiltInWidgets.kNumberBar)
                                 .withProperties(Map.of("min", 0, "max", Constants.MAXIMUM_DETECTABLE_RANGE)).getEntry();
-                shooterHoodAngle = shootingReadout.add("Hood angle (radians)", hoodAngle)
+                shooterHoodAngleDegrees = shootingReadout.add("Hood angle (degrees)", hoodAngle)
                                 .withWidget(BuiltInWidgets.kNumberBar)
                                 .withProperties(Map.of("min", shooter.hoodAngleLow * 180.0 / Math.PI, "max",
                                                 shooter.hoodAngleHigh * 180.0 / Math.PI))
@@ -280,7 +280,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
 
                 flywheelVelocity = shooter.getFlywheelVelocity();
                 flywheelTargetVelocity = shooter.getFlywheelTargetVelocity();
-                hoodAngle = Units.radiansToDegrees(shooter.getHoodAngle());
+                hoodAngle = shooter.getHoodAngle();
                 hoodPosition = shooter.getHoodPosition();
                 flywheelTemp1 = shooter.getFlywheelTemperatures()[0];
                 flywheelTemp2 = shooter.getFlywheelTemperatures()[1];
@@ -329,9 +329,8 @@ public class ShuffleboardWidgets extends SubsystemBase {
 
                 portTrackerHasData.setBoolean(portTracker.getPortData(new PowerPortData()));
                 sensorRange.setDouble(portTracker.getRange());
-                shooterHoodAngle.setDouble(hoodAngle);
+                shooterHoodAngleDegrees.setDouble(Units.radiansToDegrees(hoodAngle));
                 shooterFlywheelSpeed.setDouble(flywheelVelocity);
-
         }
 
         private void updateAutoChooser() {

--- a/src/main/java/frc/robot/ShuffleboardWidgets.java
+++ b/src/main/java/frc/robot/ShuffleboardWidgets.java
@@ -57,6 +57,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private static ShuffleboardLayout cellTracking;
         private static ShuffleboardLayout portTracking;
         private static ShuffleboardLayout shootingReadout;
+        private static ShuffleboardLayout warningReadout;
 
         private Drivetrain drivetrain;
         private Collector collector;
@@ -106,6 +107,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private int portX = 0;
         private int portY = 0;
 
+        private boolean collectorStalled = false;
+        private boolean hoodGearSlipping = false;
+
         private NetworkTableEntry[] autosE = new NetworkTableEntry[autoNum];
 
         private NetworkTableEntry robotAngE;
@@ -148,6 +152,10 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private NetworkTableEntry sensorRange;
         private NetworkTableEntry portTrackerHasData;
 
+        private NetworkTableEntry isCollectorStalled;
+        private NetworkTableEntry isHoodGearSlipping;
+        private NetworkTableEntry isShooterCurrentHigh;
+
         public ShuffleboardWidgets(Drivetrain drivetrain, Collector collector, Magazine magazine, Turret turret,
                         Shooter shooter, PowerCellTracker cellTracker, PowerPortTracker portTracker) {
                 this.drivetrain = drivetrain;
@@ -178,6 +186,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 cellTracking = tab.getLayout("CellTracker", BuiltInLayouts.kList).withSize(1, 2).withPosition(3, 0);
                 portTracking = tab.getLayout("PortTracker", BuiltInLayouts.kList).withSize(1, 2).withPosition(4, 0);
                 shootingReadout = tab.getLayout("Shooter readouts", BuiltInLayouts.kList).withSize(2, 5).withPosition(5,0);
+                warningReadout = tab.getLayout("Mechanism warnings", BuiltInLayouts.kList).withSize(3, 5).withPosition(6,0);
 
                 hoodMax = shooter.maxHoodPosition;
                 hoodMin = shooter.minHoodPosition;
@@ -255,6 +264,11 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 shooterFlywheelSpeed = shootingReadout.add("Flywheel speed (radians/s)", flywheelVelocity)
                                 .withWidget(BuiltInWidgets.kNumberBar)
                                 .withProperties(Map.of("min", 0, "max", Constants.MAX_FLYWHEEL_SPEED)).getEntry();
+                
+                isCollectorStalled = warningReadout.add("IS COLLECTOR STALLED", !collectorStalled)
+                                .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
+                isHoodGearSlipping = warningReadout.add("IS HOOD GEAR SLIPPING", !hoodGearSlipping)
+                                .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
         }
 
         private void updateWidgets() {
@@ -295,6 +309,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 portX = portData.cx;
                 portY = portData.cy;
 
+                collectorStalled = collector.isStalled();
+                hoodGearSlipping = shooter.isHoodGearSlipping();
+
                 robotAngE.setDouble(robotAng);
                 robotAngleE.setDouble(robotAngle);
                 robotXE.setDouble(robotX);
@@ -331,6 +348,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 sensorRange.setDouble(portTracker.getRange());
                 shooterHoodAngleDegrees.setDouble(Units.radiansToDegrees(hoodAngle));
                 shooterFlywheelSpeed.setDouble(flywheelVelocity);
+
+                isCollectorStalled.setBoolean(!collectorStalled);
+                isHoodGearSlipping.setBoolean(!hoodGearSlipping);
         }
 
         private void updateAutoChooser() {

--- a/src/main/java/frc/robot/ShuffleboardWidgets.java
+++ b/src/main/java/frc/robot/ShuffleboardWidgets.java
@@ -109,6 +109,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
 
         private boolean collectorStalled = false;
         private boolean hoodGearSlipping = false;
+        private boolean turretAtLimit = false;
 
         private NetworkTableEntry[] autosE = new NetworkTableEntry[autoNum];
 
@@ -155,6 +156,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
         private NetworkTableEntry isCollectorStalled;
         private NetworkTableEntry isHoodGearSlipping;
         private NetworkTableEntry isShooterCurrentHigh;
+        private NetworkTableEntry isTurretAtLimit;
 
         public ShuffleboardWidgets(Drivetrain drivetrain, Collector collector, Magazine magazine, Turret turret,
                         Shooter shooter, PowerCellTracker cellTracker, PowerPortTracker portTracker) {
@@ -186,7 +188,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 cellTracking = tab.getLayout("CellTracker", BuiltInLayouts.kList).withSize(1, 2).withPosition(3, 0);
                 portTracking = tab.getLayout("PortTracker", BuiltInLayouts.kList).withSize(1, 2).withPosition(4, 0);
                 shootingReadout = tab.getLayout("Shooter readouts", BuiltInLayouts.kList).withSize(2, 5).withPosition(5,0);
-                warningReadout = tab.getLayout("Mechanism warnings", BuiltInLayouts.kList).withSize(3, 5).withPosition(6,0);
+                warningReadout = tab.getLayout("Mechanism warnings", BuiltInLayouts.kList).withSize(2, 5).withPosition(6,0);
 
                 hoodMax = shooter.maxHoodPosition;
                 hoodMin = shooter.minHoodPosition;
@@ -265,10 +267,18 @@ public class ShuffleboardWidgets extends SubsystemBase {
                                 .withWidget(BuiltInWidgets.kNumberBar)
                                 .withProperties(Map.of("min", 0, "max", Constants.MAX_FLYWHEEL_SPEED)).getEntry();
                 
-                isCollectorStalled = warningReadout.add("IS COLLECTOR STALLED", !collectorStalled)
-                                .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
-                isHoodGearSlipping = warningReadout.add("IS HOOD GEAR SLIPPING", !hoodGearSlipping)
-                                .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
+                isCollectorStalled = warningReadout.add("IS COLLECTOR STALLED", collectorStalled)
+                                .withWidget(BuiltInWidgets.kBooleanBox)
+                                .withProperties(Map.of("Color when false","#1f1f1f","Color when true","#ff0000"))
+                                .getEntry();
+                isHoodGearSlipping = warningReadout.add("IS HOOD GEAR SLIPPING", hoodGearSlipping)
+                                .withWidget(BuiltInWidgets.kBooleanBox)
+                                .withProperties(Map.of("Color when false","#1f1f1f","Color when true","#ff0000"))
+                                .getEntry();
+                isTurretAtLimit = warningReadout.add("IS TURRET AT LIMIT", turretAtLimit)
+                                .withWidget(BuiltInWidgets.kBooleanBox)
+                                .withProperties(Map.of("Color when false","#1f1f1f","Color when true","#ff0000"))
+                                .getEntry();
         }
 
         private void updateWidgets() {
@@ -311,6 +321,7 @@ public class ShuffleboardWidgets extends SubsystemBase {
 
                 collectorStalled = collector.isStalled();
                 hoodGearSlipping = shooter.isHoodGearSlipping();
+                turretAtLimit = turret.isAtEndpoint();
 
                 robotAngE.setDouble(robotAng);
                 robotAngleE.setDouble(robotAngle);
@@ -349,8 +360,9 @@ public class ShuffleboardWidgets extends SubsystemBase {
                 shooterHoodAngleDegrees.setDouble(Units.radiansToDegrees(hoodAngle));
                 shooterFlywheelSpeed.setDouble(flywheelVelocity);
 
-                isCollectorStalled.setBoolean(!collectorStalled);
-                isHoodGearSlipping.setBoolean(!hoodGearSlipping);
+                isCollectorStalled.setBoolean(collectorStalled);
+                isHoodGearSlipping.setBoolean(hoodGearSlipping);
+                isHoodGearSlipping.setBoolean(turretAtLimit);
         }
 
         private void updateAutoChooser() {

--- a/src/main/java/frc/robot/commands/TargetFlywheelCommand.java
+++ b/src/main/java/frc/robot/commands/TargetFlywheelCommand.java
@@ -31,22 +31,16 @@ public class TargetFlywheelCommand extends CommandBase {
    * port.
    **/
   InterpolatorTable flywheelTableHigh = new InterpolatorTable(
-      /* Old high interpolator table (need to redo this later). */
-      // new InterpolatorTableEntry(1.6, 332.0),
-      // new InterpolatorTableEntry(1.8, 348.0),
-      // new InterpolatorTableEntry(3.48, 410.1),
-      // new InterpolatorTableEntry(4.86, 509.8),
-      // new InterpolatorTableEntry(6.18,527.15)
-
-      /*
-       * This is just a copy of the low interpolator table. Until we fix the data,
-       * we'll use this.
-       */
-      new InterpolatorTableEntry(1.79, 281.25), new InterpolatorTableEntry(2.35, 343.75),
-      new InterpolatorTableEntry(3.05, 343.75), new InterpolatorTableEntry(3.54, 375),
-      new InterpolatorTableEntry(3.97, 406.25), new InterpolatorTableEntry(4.56, 437.3),
-      new InterpolatorTableEntry(5.02, 437.3), new InterpolatorTableEntry(5.51, 468.75),
-      new InterpolatorTableEntry(6.03, 468.75), new InterpolatorTableEntry(6.51, 468.75));
+    new InterpolatorTableEntry(1.52, 312.5),
+    new InterpolatorTableEntry(2.01, 336.94),
+    new InterpolatorTableEntry(2.50, 332.57),
+    new InterpolatorTableEntry(3.00, 383.82),
+    new InterpolatorTableEntry(3.52, 421.875),
+    new InterpolatorTableEntry(4.04, 437.5),
+    new InterpolatorTableEntry(4.54, 453.125),
+    new InterpolatorTableEntry(5.01, 468.75),
+    new InterpolatorTableEntry(5.49, 500.00)
+  );
 
   /** Table for shooting in 107, or anywhere else with the small power port. **/
   InterpolatorTable flywheelTableLow = new InterpolatorTable(

--- a/src/main/java/frc/robot/commands/TargetHoodCommand.java
+++ b/src/main/java/frc/robot/commands/TargetHoodCommand.java
@@ -36,11 +36,15 @@ public class TargetHoodCommand extends CommandBase {
 
   /**Table for shooting in the gym, or anywhere else with the full-size power port.**/
   InterpolatorTable hoodTableHigh = new InterpolatorTable(
-    new InterpolatorTableEntry(1.6, 0.675),
-    new InterpolatorTableEntry(1.8, 0.644),
-    new InterpolatorTableEntry(3.48, 0.515),
-    new InterpolatorTableEntry(4.86, 0.373),
-    new InterpolatorTableEntry(6.18, 0.355)
+    new InterpolatorTableEntry(1.52, 0.745),
+    new InterpolatorTableEntry(2.01, 0.667),
+    new InterpolatorTableEntry(2.50, 0.628),
+    new InterpolatorTableEntry(3.00, 0.501),
+    new InterpolatorTableEntry(3.52, 0.445),
+    new InterpolatorTableEntry(4.04, 0.406),
+    new InterpolatorTableEntry(4.54, 0.408),
+    new InterpolatorTableEntry(5.01, 0.354),
+    new InterpolatorTableEntry(5.49, 0.354)
   );
 
   /**Table for shooting in 107, or anywhere else with the small power port.**/

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -296,9 +296,7 @@ public class Shooter extends SubsystemBase {
     
     double hallSensorVelocity = hoodHallSensor.getVelocity() * 2.0 * Math.PI / 60.0;
     double quadEncoderVelocity = hoodEncoder.getVelocity() * 2.0 * Math.PI / 60.0;
-    if ((Math.abs(hallSensorVelocity) >= 1.0) && (Math.abs(quadEncoderVelocity / hallSensorVelocity) < 0.5)) {
-      isHoodGearSlipping = true;
-    }
+    isHoodGearSlipping = ((Math.abs(hallSensorVelocity) >= 1.0) && (Math.abs(quadEncoderVelocity) <= 0.05));
 
     flywheelTemperatures[0] = shooterFlywheel1.getTemperature();
     flywheelTemperatures[1] = shooterFlywheel2.getTemperature();

--- a/src/main/java/frc/robot/subsystems/Turret.java
+++ b/src/main/java/frc/robot/subsystems/Turret.java
@@ -60,6 +60,13 @@ public class Turret extends SubsystemBase {
       return turretRotator.getSelectedSensorVelocity(0) * 10.0 / turretTicksPerRadian;
     }
 
+    /**
+     * Returns true if the turret is at the programmed end positions.
+     */
+    public boolean isAtEndpoint() {
+      return ((getPosition() < turretMinimumAngle) || (getPosition() > turretMaximumAngle));
+    }
+
     /// Sets the velocity of the turret in radians/second.
     public void setVelocity(double angularVelocity) {
       if ((getPosition() < turretMinimumAngle && angularVelocity < 0) || (getPosition() > turretMaximumAngle && angularVelocity > 0)) {


### PR DESCRIPTION
The interpolator tables are the ones we collected last week, and they seem to be good enough to score with some consistency. I also added in some warning indicators on Shuffleboard in their own list group for when mechanisms on the robot fail or aren't working. Currently the only ones on there are to indicate that the collector is stalled, that the hood gear is slipping, and that the turret is at one of the endpoint positions, but I'll add more on when it's reasonable to do so. Aside from a couple of small fixes, the code here is the same code we used for drive practice on Saturday, so I think it would be good if we merged this branch so we can have a good starting point for bugfixes and all that.